### PR TITLE
Rename `check_ir` to `check_allocs` and update README

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["JuliaHub Inc."]
 version = "1.0.0-DEV"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 GPUCompiler = "61eb1bfa-7361-4325-ad38-22787b887f55"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,36 @@
 <!-- [![Build Status](https://github.com/gbaraldi/AllocCheck.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/gbaraldi/AllocCheck.jl/actions/workflows/CI.yml?query=branch%3Amain) -->
 
 AllocCheck.jl is a Julia package that statically checks if a function call may allocate, analyzing the generated LLVM IR of it and it's callees using LLVM.jl and GPUCompiler.jl
+
+#### Examples
+
+```julia
+julia> mymod(x) = mod(x, 2.5)
+
+julia> length(check_allocs(mymod, (Float64,)))
+0
+
+julia> linsolve(a, b) = a \ b
+
+julia> length(check_allocs(linsolve, (Matrix{Float64}, Vector{Float64})))
+175
+```
+
+#### Known Limitations
+
+ 1. Error paths
+
+   Allocations in error-throwing paths are not distinguished from other allocations:
+
+```julia
+julia> check_allocs(sin, (Float64,))[1]
+
+Allocation of Float64 in ./special/trig.jl:28
+  | @noinline sin_domain_error(x) = throw(DomainError(x, "sin(x) is only defined for finite x."))
+
+Stacktrace:
+ [1] sin_domain_error(x::Float64)
+   @ Base.Math ./special/trig.jl:28
+ [2] sin(x::Float64)
+   @ Base.Math ./special/trig.jl:39
+```

--- a/src/allocfunc.jl
+++ b/src/allocfunc.jl
@@ -108,7 +108,6 @@ function rename_ir!(job, inst::LLVM.CallInst)
     world = job.world
     interp = GPUCompiler.get_interpreter(job)
     method_table = Core.Compiler.method_table(interp)
-    bt = backtrace(inst)
     dest = called_operand(inst)
 
     if isa(dest, ConstantExpr)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,41 @@
+using Base64
+
+file_exists_at(x) = try isfile(x); catch; false end
+const BUILDBOT_STDLIB_PATH = dirname(abspath(String(pathof(Base64)), "..", "..", ".."))
+replace_buildbot_stdlibpath(str::String) = replace(str, BUILDBOT_STDLIB_PATH => Sys.STDLIB)
+
+"""
+    path = fixup_stdlib_source_path(path::String)
+
+Return `path` corrected for julia issue [#26314](https://github.com/JuliaLang/julia/issues/26314) if applicable.
+Otherwise, return the input `path` unchanged.
+
+Due to the issue mentioned above, location info for methods defined one of Julia's standard libraries
+are, for non source Julia builds, given as absolute paths on the worker that built the `julia` executable.
+This function corrects such a path to instead refer to the local path on the users drive.
+"""
+function fixup_stdlib_source_path(path)
+    if !file_exists_at(path)
+        maybe_stdlib_path = replace_buildbot_stdlibpath(path)
+        file_exists_at(maybe_stdlib_path) && return maybe_stdlib_path
+    end
+    return path
+end
+
+
+"""
+    path = fixup_source_path(path)
+
+Return a normalized, absolute path for a source file `path`.
+"""
+function fixup_source_path(file)
+    file = string(file)
+    if !isabspath(file)
+        # This may be a Base or Core method
+        newfile = Base.find_source_file(file)
+        if isa(newfile, AbstractString)
+            file = normpath(newfile)
+        end
+    end
+    return fixup_stdlib_source_path(file)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using AllocCheck
 using Test
 
 @testset "AllocCheck.jl" begin
-    @test length(check_ir(mod, (Float64,Float64))) == 0
-    @test length(check_ir(sin, (Float64,))) != 0 # TODO: implement detection allocations for errors
-    @test length(check_ir(*, (Matrix{Float64},Matrix{Float64}))) != 0
+    @test length(check_allocs(mod, (Float64,Float64))) == 0
+    @test length(check_allocs(sin, (Float64,))) != 0 # TODO: implement detection allocations for errors
+    @test length(check_allocs(*, (Matrix{Float64},Matrix{Float64}))) != 0
 end


### PR DESCRIPTION
- Updated README
- Tweaked printing a bit (esp. showing the allocation site instead of the LLVM instruction)
- Renamed `check_ir` to `check_allocs`