### PR TITLE
Fix test failure on master due to try-catch elision

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 
 function alloc_in_catch()
    try
+       Base.inferencebarrier(nothing) # Prevent catch from being elided
    catch
        return Any[] # in catch block: filtered by `ignore_throw=true`
    end


### PR DESCRIPTION
Inference got better, so we need an explicit barrier to prevent DCE from undoing our test.