### PR TITLE
Mark GC API functions as non-allocating

### DIFF
--- a/src/allocfunc.jl
+++ b/src/allocfunc.jl
@@ -21,6 +21,12 @@ const known_nonalloc_funcs = (
     "jl_clock_now", "ijl_clock_now",
     "jl_throw", "ijl_throw", #= the allocation of the error is separate =#
     "jl_gc_queue_root", "ijl_gc_queue_root",
+    "jl_gc_enable", "ijl_gc_enable",
+    "jl_gc_disable_finalizers_internal", "ijl_gc_disable_finalizers_internal",
+    "jl_gc_is_in_finalizer", "ijl_gc_is_in_finalizer",
+    "jl_enable_gc_logging", "ijl_enable_gc_logging",
+    "jl_gc_safepoint", "ijl_gc_safepoint",
+    "jl_gc_collect", "ijl_gc_collect", #= GC collection is not _technically_ an allocation =#
 )
 
 const known_alloc_with_throw_funcs = (
@@ -29,6 +35,7 @@ const known_alloc_with_throw_funcs = (
     "jl_f_is", "ijl_f_is",
     "jl_f_throw", "ijl_f_throw",
     "jl_f__svec_ref", "ijl_f__svec_ref",
+    "jl_gc_enable_finalizers_internal", "ijl_gc_enable_finalizers_internal",
 )
 
 function is_alloc_function(name, ignore_throw)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,15 @@ function throw_eof()
     throw(EOFError())
 end
 
+function toggle_gc()
+    GC.enable(false)
+    GC.enable(true)
+end
+
+function run_gc_explicitly()
+    GC.gc()
+end
+
 @testset "AllocCheck.jl" begin
     @test length(check_allocs(mod, (Float64,Float64); ignore_throw=false)) == 0
     @test length(check_allocs(sin, (Float64,); ignore_throw=false)) > 0
@@ -34,6 +43,9 @@ end
 
     @test length(check_allocs(first, (Core.SimpleVector,); ignore_throw = false)) > 0
     @test length(check_allocs(first, (Core.SimpleVector,); ignore_throw = true)) == 0
+
     @test length(check_allocs(time, (); ignore_throw = false)) == 0
     @test length(check_allocs(throw_eof, (); ignore_throw = false)) == 0
+    @test length(check_allocs(toggle_gc, (); ignore_throw = false)) == 0
+    @test length(check_allocs(run_gc_explicitly, (); ignore_throw = false)) == 0
 end


### PR DESCRIPTION
These might enable/disable garbage collection, but they don't themselves trigger a safepoint or allocate objects.

Open Question: What should we do with `GC.safepoint()` and `GC.gc()`?
They are technically not allocating, but many users may want to prohibit them anyway.