### PR TITLE
Add `@check_allocs` macro to enforce allocation checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["JuliaHub Inc."]
 version = "1.0.0-DEV"
 
 [deps]
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 GPUCompiler = "61eb1bfa-7361-4325-ad38-22787b887f55"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
 GPUCompiler = "0.24"

--- a/src/abi_call.jl
+++ b/src/abi_call.jl
@@ -1,0 +1,82 @@
+import GPUCompiler, LLVM
+using LLVM: LLVMType
+
+# https://github.com/JuliaGPU/GPUCompiler.jl/blob/21ca075c1e91fe0c15f1330ab487b4831013ec1f/examples/jit.jl#L145-L222
+@generated function abi_call(f::Ptr{Cvoid}, rt::Type{RT}, tt::Type{T}, func::F, args::Vararg{Any, N}) where {T, RT, F, N}
+    argtt    = tt.parameters[1]
+    rettype  = rt.parameters[1]
+    argtypes = DataType[argtt.parameters...]
+
+    argexprs = Union{Expr, Symbol}[]
+    ccall_types = DataType[]
+
+    before = :()
+    after = :(ret)
+
+    # Note this follows: emit_call_specfun_other
+    JuliaContext() do ctx
+        if !GPUCompiler.isghosttype(F) && !Core.Compiler.isconstType(F)
+            isboxed = GPUCompiler.deserves_argbox(F)
+            argexpr = :(func)
+            if isboxed
+                push!(ccall_types, Any)
+            else
+                et = convert(LLVMType, func)
+                if isa(et, LLVM.SequentialType) # et->isAggregateType
+                    push!(ccall_types, Ptr{F})
+                    argexpr = Expr(:call, GlobalRef(Base, :Ref), argexpr)
+                else
+                    push!(ccall_types, F)
+                end
+            end
+            push!(argexprs, argexpr)
+        end
+
+        T_jlvalue = LLVM.StructType(LLVMType[])
+        T_prjlvalue = LLVM.PointerType(T_jlvalue, #= AddressSpace::Tracked =# 10)
+
+        for (source_i, source_typ) in enumerate(argtypes)
+            if GPUCompiler.isghosttype(source_typ) || Core.Compiler.isconstType(source_typ)
+                continue
+            end
+
+            argexpr = :(args[$source_i])
+
+            isboxed = GPUCompiler.deserves_argbox(source_typ)
+            et = isboxed ? T_prjlvalue : convert(LLVMType, source_typ)
+
+            if isboxed
+                push!(ccall_types, Any)
+            elseif isa(et, LLVM.SequentialType) # et->isAggregateType
+                push!(ccall_types, Ptr{source_typ})
+                argexpr = Expr(:call, GlobalRef(Base, :Ref), argexpr)
+            else
+                push!(ccall_types, source_typ)
+            end
+            push!(argexprs, argexpr)
+        end
+
+        if GPUCompiler.isghosttype(rettype) || Core.Compiler.isconstType(rettype)
+            # Do nothing...
+            # In theory we could set `rettype` to `T_void`, but ccall will do that for us
+        # elseif jl_is_uniontype?
+        elseif !GPUCompiler.deserves_retbox(rettype)
+            rt = convert(LLVMType, rettype)
+            if !isa(rt, LLVM.VoidType) && GPUCompiler.deserves_sret(rettype, rt)
+                before = :(sret = Ref{$rettype}())
+                pushfirst!(argexprs, :(sret))
+                pushfirst!(ccall_types, Ptr{rettype})
+                rettype = Nothing
+                after = :(sret[])
+            end
+        else
+            # rt = T_prjlvalue
+        end
+    end
+
+    quote
+        $before
+        ret = ccall(f, $rettype, ($(ccall_types...),), $(argexprs...))
+        $after
+    end
+end

--- a/src/allocfunc.jl
+++ b/src/allocfunc.jl
@@ -187,10 +187,7 @@ end
 
 import GPUCompiler: DYNAMIC_CALL, DELAYED_BINDING, RUNTIME_FUNCTION, UNKNOWN_FUNCTION, POINTER_FUNCTION
 import GPUCompiler: backtrace, isintrinsic
-function rename_ir!(job, inst::LLVM.CallInst)
-    world = job.world
-    interp = GPUCompiler.get_interpreter(job)
-    method_table = Core.Compiler.method_table(interp)
+function rename_ir!(inst::LLVM.CallInst)
     dest = called_operand(inst)
 
     if isa(dest, LLVM.LoadInst)
@@ -217,7 +214,7 @@ function rename_ir!(job, inst::LLVM.CallInst)
         if occursin("inttoptr", string(dest))
             # extract the literal pointer
             ptr_arg = first(operands(dest))
-            GPUCompiler.@compiler_assert isa(ptr_arg, ConstantInt) job
+            # GPUCompiler.@compiler_assert isa(ptr_arg, ConstantInt) job
             ptr_val = convert(Int, ptr_arg)
             ptr = Ptr{Cvoid}(ptr_val)
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1,0 +1,160 @@
+import LLVM, GPUCompiler
+using LLVM: TargetMachine, @dispose
+using GPUCompiler: CompilerConfig, CompilerJob, MemoryBuffer, NativeCompilerTarget, JuliaContext, ThreadSafeContext, run!
+
+include("compiler_utils.jl")
+
+function __init__()
+    opt_level = Base.JLOptions().opt_level
+
+    tm[] = LLVM.JITTargetMachine(LLVM.triple(), cpu_name(), cpu_features();
+                                 optlevel = llvm_codegen_level(opt_level))
+    LLVM.asm_verbosity!(tm[], true)
+    lljit = LLVM.has_julia_ojit() ? LLVM.JuliaOJIT() : LLVM.LLJIT(; tm=tm[])
+
+    jd_main = LLVM.JITDylib(lljit)
+
+    prefix = LLVM.get_prefix(lljit)
+    dg = LLVM.CreateDynamicLibrarySearchGeneratorForProcess(prefix)
+    LLVM.add!(jd_main, dg)
+
+    # TODO: Do we need this trick from Enzyme?
+    # if Sys.iswindows() && Int === Int64
+        # # TODO can we check isGNU?
+        # define_absolute_symbol(jd_main, mangle(lljit, "___chkstk_ms"))
+    # end
+
+    es = LLVM.ExecutionSession(lljit)
+    try
+        lctm = LLVM.LocalLazyCallThroughManager(GPUCompiler.triple(lljit), es)
+        ism = LLVM.LocalIndirectStubsManager(GPUCompiler.triple(lljit))
+        jit[] = CompilerInstance(lljit, lctm, ism)
+    catch err
+        @warn "OrcV2 initialization failed with" err
+        jit[] = CompilerInstance(lljit, nothing, nothing)
+    end
+end
+
+@static if LLVM.has_julia_ojit()
+    struct CompilerInstance
+        jit::LLVM.JuliaOJIT
+        lctm::Union{LLVM.LazyCallThroughManager, Nothing}
+        ism::Union{LLVM.IndirectStubsManager, Nothing}
+    end
+else
+    struct CompilerInstance
+        jit::LLVM.LLJIT
+        lctm::Union{LLVM.LazyCallThroughManager, Nothing}
+        ism::Union{LLVM.IndirectStubsManager, Nothing}
+    end
+end
+
+struct CompileResult{Success, F, TT, RT}
+    f_ptr::Ptr{Cvoid}
+    arg_types::Type{TT}
+    return_type::Type{RT}
+    func::F
+    analysis # TODO: add type
+end
+
+# lock + JIT objects
+const codegen_lock = ReentrantLock()
+const jit = Ref{CompilerInstance}()
+const tm = Ref{TargetMachine}() # for opt pipeline
+
+# cache of kernel instances
+const _kernel_instances = Dict{Any, Any}()
+const compiler_cache = Dict{Any, CompileResult}()
+const config = CompilerConfig(DefaultCompilerTarget(), NativeParams();
+                              kernel=false, entry_abi = :specfunc, always_inline=false)
+
+const NativeCompilerJob = CompilerJob{NativeCompilerTarget,NativeParams}
+GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = true
+GPUCompiler.runtime_module(::NativeCompilerJob) = Runtime
+
+function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
+    triple = GPUCompiler.llvm_triple(job.config.target)
+    tm = GPUCompiler.llvm_machine(job.config.target)
+    if VERSION >= v"1.10-beta3"
+        @dispose pb = LLVM.PassBuilder(tm) begin
+            @dispose mpm = LLVM.NewPMModulePassManager(pb) begin
+                build_newpm_pipeline!(pb, mpm)
+                run!(mpm, mod, tm)
+            end
+        end
+    else
+        @dispose pm=LLVM.ModulePassManager() begin
+            build_oldpm_pipeline!(pm)
+            run!(pm, mod)
+        end
+    end
+end
+
+"""
+    compile_callable(f, tt=Tuple{}; kwargs...)
+
+Low-level interface to compile a function invocation for the provided function and tuple of
+argument types using the naive JuliaOJIT() pipeline.
+
+The output of this function is automatically cached, so that new code will be generated
+automatically and checked for allocations whenever the function changes or when different
+types or keyword arguments are provided.
+"""
+function compile_callable(f::F, tt::TT=Tuple{}; ignore_throw=true) where {F, TT}
+    # cuda = active_state()
+
+    Base.@lock codegen_lock begin
+        # compile the function
+        cache = compiler_cache
+        source = GPUCompiler.methodinstance(F, tt)
+        rt = Core.Compiler.return_type(f, tt)
+
+        function compile(@nospecialize(job::CompilerJob))
+            return JuliaContext() do ctx
+                mod, meta = GPUCompiler.compile(:llvm, job, validate=false)
+                optimize!(job, mod)
+
+                clone = copy(mod)
+                analysis = find_allocs!(mod, meta; ignore_throw)
+                # TODO: This is the wrong meta
+                return clone, meta, analysis
+            end
+        end
+        function link(@nospecialize(job::CompilerJob), (mod, meta, analysis))
+            return JuliaContext() do ctx
+                lljit = jit[].jit
+                jd = LLVM.JITDylib(lljit)
+                buf = convert(MemoryBuffer, mod)
+                tsm = ThreadSafeContext() do ctx
+                    mod = parse(LLVM.Module, buf)
+                    GPUCompiler.ThreadSafeModule(mod)
+                end
+                LLVM.add!(lljit, jd, tsm)
+                f_ptr = pointer(LLVM.lookup(lljit, LLVM.name(meta.entry)))
+                if f_ptr == C_NULL
+                    throw(GPUCompiler.InternalCompilerError(job,
+                          "Failed to compile @check_allocs function"))
+                end
+                if length(analysis) == 0
+                    CompileResult{true, typeof(f), tt, rt}(f_ptr, tt, rt, f, analysis)
+                else
+                    CompileResult{false, typeof(f), tt, rt}(f_ptr, tt, rt, f, analysis)
+                end
+            end
+        end
+        fun = GPUCompiler.cached_compilation(cache, source, config, compile, link)
+
+        # create a callable object that captures the function instance. we don't need to think
+        # about world age here, as GPUCompiler already does and will return a different object
+        key = (objectid(source), hash(fun), f)
+        return get(_kernel_instances, key, fun)::CompileResult
+    end
+end
+
+function (f::CompileResult{Success, F, TT, RT})(args...) where {Success, F, TT, RT}
+    if Success
+        return abi_call(f.f_ptr, RT, TT, f.func, args...)
+    else
+        error("@check_alloc function contains ", length(f.analysis), " allocations.")
+    end
+end

--- a/src/compiler_utils.jl
+++ b/src/compiler_utils.jl
@@ -1,0 +1,48 @@
+import LLVM, GPUCompiler
+using GPUCompiler: NativeCompilerTarget
+
+struct NativeParams <: GPUCompiler.AbstractCompilerParams end
+
+DefaultCompilerTarget(; kwargs...) = NativeCompilerTarget(; jlruntime=true, kwargs...)
+
+function llvm_codegen_level(opt_level::Integer)
+    if opt_level < 2
+        optlevel = LLVM.API.LLVMCodeGenLevelNone
+    elseif opt_level == 2
+        optlevel = LLVM.API.LLVMCodeGenLevelDefault
+    else
+        optlevel = LLVM.API.LLVMCodeGenLevelAggressive
+    end
+end
+
+function cpu_name()
+    ccall(:jl_get_cpu_name, String, ())
+end
+
+function cpu_features()
+    if VERSION >= v"1.10.0-beta1"
+        return ccall(:jl_get_cpu_features, String, ())
+    end
+
+    @static if Sys.ARCH == :x86_64 ||
+               Sys.ARCH == :x86
+        return "+mmx,+sse,+sse2,+fxsr,+cx8" # mandated by Julia
+    else
+        return ""
+    end
+end
+
+if VERSION >= v"1.10-beta3"
+    function build_newpm_pipeline!(pb::LLVM.PassBuilder, mpm::LLVM.NewPMModulePassManager, speedup=2, size=0, lower_intrinsics=true,
+        dump_native=false, external_use=false, llvm_only=false,)
+        ccall(:jl_build_newpm_pipeline, Cvoid,
+            (LLVM.API.LLVMModulePassManagerRef, LLVM.API.LLVMPassBuilderRef, Cint, Cint, Cint, Cint, Cint, Cint),
+            mpm, pb, speedup, size, lower_intrinsics, dump_native, external_use, llvm_only)
+    end
+else
+    function build_oldpm_pipeline!(pm::LLVM.ModulePassManager, opt_level=2, lower_intrinsics=true)
+        ccall(:jl_add_optimization_passes, Cvoid,
+                    (LLVM.API.LLVMPassManagerRef, Cint, Cint),
+                    pm, opt_level, lower_intrinsics)
+    end
+end


### PR DESCRIPTION
This allows a user to enforce that a function will not be called with any set of arguments that would trigger unbounded allocation in its body:

```julia
@check_allocs energy(x) = sum(abs2.(x))

@check_allocs function pythag(a, b, c)
    return a^2 + b^2 + c^2
end

const inplace_sum = @check_allocs (x, y) -> x .= x .+ y
```

TODO: 
- [x] Add allocation check to the pipeline
- [x] Add tests for all of the different function syntaxes

Resolves #30