### PR TITLE
Add warning to `check_allocs(...)`

### DIFF
--- a/src/AllocCheck.jl
+++ b/src/AllocCheck.jl
@@ -170,7 +170,18 @@ end
     check_allocs(func, types; ignore_throw=true)
 
 Compiles the given function and types to LLVM IR and checks for allocations.
-Returns a vector of `AllocationSite` structs, each containing a `CallInst` and a backtrace.
+
+Returns a vector of `AllocationSite`, `DynamicDispatch`, and `AllocatingRuntimeCall`
+
+!!! warning
+    The Julia language/compiler does not guarantee that this result is stable across
+    Julia invocations.
+
+    If you rely on allocation-free code for safety/correctness, it is not sufficient
+    to verify `check_allocs` in test code and expect that the corresponding call in
+    production will not allocate at runtime.
+
+    For this case, you must use `@check_allocs` instead.
 
 # Example
 ```jldoctest


### PR DESCRIPTION
The results from `check_allocs(foo, (...))` cannot strictly be expected to apply across Julia invocations or across any new method definitions (i.e. worlds). Furthermore, we don't have yet have sufficient testing to guarantee that our optimization pipeline in GPUCompiler will never diverge (however slightly) from the base Julia pipeline. 

The unfortunate result is that we don't have the parity/stability guarantees we need from the Julia compiler to use `check_allocs(foo, ...)` for allocation-free guarantees at runtime.

This adds a note to clarify that such a usage is unsound.