### PR TITLE
Fix typo: `@check_alloc` -> `@check_allocs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ julia> multiply(1.5, 2.5) # call automatically checked for allocations
 3.75
 
 julia> multiply(rand(3, 3), rand(3, 3)) # result matrix requires an allocation
-ERROR: @check_alloc function encountered 1 errors (1 allocations / 0 dynamic dispatches).
+ERROR: @check_allocs function encountered 1 errors (1 allocations / 0 dynamic dispatches).
 ```
 
 The `multiply(::Float64, ::Float64)` call happened without error, indicating that the function was proven not to allocate. On the other hand, the `multiply(::Matrix{Float64}, ::Matrix{Float64})` call raised an `AllocCheckFailure` due to one internal allocation.
@@ -75,7 +75,7 @@ julia> mysin1(1.5)
 0.9974949866040544
 
 julia> mysin2(1.5)
-ERROR: @check_alloc function encountered 2 errors (1 allocations / 1 dynamic dispatches).
+ERROR: @check_allocs function encountered 2 errors (1 allocations / 1 dynamic dispatches).
 ```
 
 #### Limitations

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -155,6 +155,6 @@ function (f::CompileResult{Success, F, TT, RT})(args...) where {Success, F, TT, 
     if Success
         return abi_call(f.f_ptr, RT, TT, f.func, args...)
     else
-        error("@check_alloc function contains ", length(f.analysis), " allocations.")
+        error("@check_allocs function contains ", length(f.analysis), " allocations.")
     end
 end

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -43,7 +43,7 @@ julia> multiply(1.5, 3.5) # no allocations for Float64
 5.25
 
 julia> multiply(rand(3,3), rand(3,3)) # matmul needs to allocate the result
-ERROR: @check_alloc function contains 1 allocations.
+ERROR: @check_allocs function contains 1 allocations.
 
 Stacktrace:
  [1] macro expansion

--- a/src/types.jl
+++ b/src/types.jl
@@ -128,7 +128,7 @@ function Base.show(io::IO, failure::AllocCheckFailure)
     allocs = count(err isa AllocationSite || err isa AllocatingRuntimeCall for err in failure.errors)
     dispatches = count(err isa DynamicDispatch for err in failure.errors)
 
-    Base.print(io, "@check_alloc function encountered ")
+    Base.print(io, "@check_allocs function encountered ")
     Base.printstyled(io, length(failure.errors), color=:red, bold=true)
     Base.print(io, " errors ($(allocs) allocations / $(dispatches) dynamic dispatches).")
 end


### PR DESCRIPTION
The error message for `@check_allocs` is missing the `s` in a few places in the code and the docs.