### PR TITLE
Implement `:func` ABI for calling GPUCompiler emitted code

### DIFF
--- a/src/AllocCheck.jl
+++ b/src/AllocCheck.jl
@@ -202,7 +202,7 @@ function check_allocs(@nospecialize(func), @nospecialize(types); ignore_throw=tr
     end
     source = GPUCompiler.methodinstance(Base._stable_typeof(func), Base.to_tuple_type(types))
     target = DefaultCompilerTarget()
-    job = CompilerJob(source, config)
+    job = CompilerJob(source, specsig_config)
     allocs = JuliaContext() do ctx
         mod, meta = GPUCompiler.compile(:llvm, job, validate=false, optimize=false, cleanup=false)
         optimize!(job, mod)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -327,8 +327,26 @@ Documentation for `issue64`.
   v[i], v[j] = v[j], v[i]
   v
 end
-let io = IOBuffer()
-    print(io, @doc issue64)
-    s = String(take!(io))
-    @test occursin("Documentation for `issue64`.", s)
+
+@check_allocs function foo_with_union_rt(t::Tuple{Float64, Float64})
+    if rand((1, -1)) == 1
+        return t
+    else
+        return nothing
+    end
+end
+
+@testset "issues" begin
+    # issue #64
+    let io = IOBuffer()
+        print(io, @doc issue64)
+        s = String(take!(io))
+        @test occursin("Documentation for `issue64`.", s)
+    end
+
+    # issue #70
+    x = foo_with_union_rt((1.0, 1.5))
+    @test x === nothing || x === (1.0, 1.5)
+    x = foo_with_union_rt((1.0, 1.5))
+    @test x === nothing || x === (1.0, 1.5)
 end


### PR DESCRIPTION
This ABI is always ccallable, unlike the `:specfunc` ABI which frequently is not.

However, this ABI comes with a trade-off of introducing allocations (almost) always for function entry/exit. For that reason, we should re-enable the `:specfunc` ABI as soon as we can on as many types as possible.

Resolves #70 