### PR TITLE
Adapt to GPUCompiler.jl API changes.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-GPUCompiler = "0.27,1"
+GPUCompiler = "1.3"
 LLVM = "9.1"
 ExprTools = "0.1"
 MacroTools = "0.5"

--- a/src/AllocCheck.jl
+++ b/src/AllocCheck.jl
@@ -217,10 +217,10 @@ function check_allocs(@nospecialize(func), @nospecialize(types); ignore_throw=tr
         throw(MethodError(func, types))
     end
     source = GPUCompiler.methodinstance(Base._stable_typeof(func), Base.to_tuple_type(types))
-    target = DefaultCompilerTarget()
-    job = CompilerJob(source, alloc_config(:specfunc))
+    config = alloc_config(:specfunc; validate=false, optimize=false, cleanup=false)
+    job = CompilerJob(source, config)
     allocs = JuliaContext() do ctx
-        mod, meta = GPUCompiler.compile(:llvm, job, validate=false, optimize=false, cleanup=false)
+        mod, meta = GPUCompiler.compile(:llvm, job)
         (; entry, compiled) = meta
         entry_name = name(entry)
         optimize!(mod)


### PR DESCRIPTION
Keyword arguments are now all stored in the `CompilerConfig` struct.