### PR TITLE
Add get_pgcstack_static to non-allocating allowlist

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,10 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        include:
+          - version: '1.12'
+            os: macos-latest
+            arch: aarch64
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v2

--- a/src/classify.jl
+++ b/src/classify.jl
@@ -66,7 +66,7 @@ function fn_may_allocate(name::AbstractString; ignore_throw::Bool)
                 "box_uint8", "excstack_state", "restore_excstack", "enter_handler",
                 "pop_handler", "pop_handler_noexcept", "f_typeof", "clock_now", "throw", "gc_queue_root", "gc_enable",
                 "gc_disable_finalizers_internal", "gc_is_in_finalizer", "enable_gc_logging",
-                "gc_safepoint", "gc_collect", "genericmemory_owner", "get_pgcstack") || occursin(r"^unbox_.*", name)
+                "gc_safepoint", "gc_collect", "genericmemory_owner", "get_pgcstack", "get_pgcstack_static") || occursin(r"^unbox_.*", name)
         return false # these functions never allocate
     elseif name in ("f_ifelse", "f_typeassert", "f_is", "f_throw", "f__svec_ref",
                     "genericmemory_copyto")


### PR DESCRIPTION
## Summary
- On arm64 (Apple Silicon), Julia uses `jl_get_pgcstack_static` instead of `jl_get_pgcstack` to access the GC stack
- This variant was missing from the `fn_may_allocate` allowlist in `src/classify.jl`, causing spurious "1 allocation" reports for every `@check_allocs`-decorated function on macOS/arm64
- Fix: add `"get_pgcstack_static"` alongside the existing `"get_pgcstack"` entry

## Context

Discovered via [Mooncake.jl#982](https://github.com/chalk-lab/Mooncake.jl/issues/982) — all `check_allocs`-based tests fail with false positives on Apple Silicon due to this missing entry. A downstream workaround was proposed in [Mooncake.jl#1092](https://github.com/chalk-lab/Mooncake.jl/pull/1092) but fixing it here upstream is the right approach.

## MWE (on arm64/Apple Silicon)

```julia
using AllocCheck
@check_allocs foo(x::Float64) = 2x
foo(1.0)
# Reports: Allocating runtime call to "jl_get_pgcstack_static" in unknown location
```