### PR TITLE
Use 3-arg LLVM.lookup to avoid deprecation warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AllocCheck"
 uuid = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 authors = ["JuliaHub Inc."]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
@@ -11,7 +11,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
 GPUCompiler = "1.3"
-LLVM = "9.1"
+LLVM = "9.8.1"
 ExprTools = "0.1"
 MacroTools = "0.5"
 julia = "1.10"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -111,7 +111,7 @@ function compile_callable(f::F, tt::TT=Tuple{}; ignore_throw=true) where {F, TT}
                     GPUCompiler.ThreadSafeModule(mod)
                 end
                 LLVM.add!(lljit, jd, tsm)
-                f_ptr = pointer(LLVM.lookup(lljit, entry_name))
+                f_ptr = pointer(LLVM.lookup(lljit, jd, entry_name))
                 if f_ptr == C_NULL
                     throw(GPUCompiler.InternalCompilerError(job,
                           "Failed to compile @check_allocs function"))


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

## Summary

LLVM.jl v9.8.1 (released 2026-05-12) added an `@deprecate` for the 2-arg `lookup(jljit::JuliaOJIT, name)` form in favor of the new 3-arg `lookup(jljit, jd, name)`. The old form was removed upstream in [JuliaLang/julia#60988](https://github.com/JuliaLang/julia/pull/60988) for Julia 1.14.0-DEV.2171.

`src/compiler.jl:114` calls `LLVM.lookup(lljit, entry_name)` from inside the `@check_allocs`-generated link path, so the depwarn fires at every JIT lookup. Downstream packages that exercise `@check_allocs` under `@test_nowarn` see the warning surface as a test failure — see [SciML/LinearSolve.jl#984](https://github.com/SciML/LinearSolve.jl/pull/984#issuecomment-4451226614) (`test/nopre/static_arrays.jl:25`).

## Fix

- Pass the already-constructed `jd::JITDylib` explicitly: `LLVM.lookup(lljit, jd, entry_name)`.
- Bump LLVM compat from `9.1` → `9.8.1` because the 3-arg `lookup(::JuliaOJIT, ::JITDylib, ::Any)` method was first introduced in v9.8.1.
- Bump package version `0.2.3` → `0.2.4`.

## Verification

Local on Julia 1.11.9 with LLVM.jl v9.8.1:

- `Pkg.test()` passes (all suites green).
- `@check_allocs` round-trip under `--depwarn=error` runs cleanly — confirming the deprecation warning is gone.

```
$ julia +1.11 --depwarn=error --project=. /tmp/test_depwarn.jl
OK: no deprecation warning
```

## Test plan

- [x] AllocCheck.jl test suite passes locally
- [x] No `LLVM.lookup` depwarn under `--depwarn=error`
- [ ] CI green on this PR
- [ ] Confirm LinearSolve.jl `test/nopre/static_arrays.jl` passes once a tagged release of AllocCheck includes this fix