### PR TITLE
fix: add `get_pgcstack_fallback` to non-allocating allowlist (aarch64 false positive)

### DIFF
--- a/src/classify.jl
+++ b/src/classify.jl
@@ -66,7 +66,8 @@ function fn_may_allocate(name::AbstractString; ignore_throw::Bool)
                 "box_uint8", "excstack_state", "restore_excstack", "enter_handler",
                 "pop_handler", "pop_handler_noexcept", "f_typeof", "clock_now", "throw", "gc_queue_root", "gc_enable",
                 "gc_disable_finalizers_internal", "gc_is_in_finalizer", "enable_gc_logging",
-                "gc_safepoint", "gc_collect", "genericmemory_owner", "get_pgcstack", "get_pgcstack_static") || occursin(r"^unbox_.*", name)
+                "gc_safepoint", "gc_collect", "genericmemory_owner", "get_pgcstack", "get_pgcstack_static",
+                "get_pgcstack_fallback") || occursin(r"^unbox_.*", name)
         return false # these functions never allocate
     elseif name in ("f_ifelse", "f_typeassert", "f_is", "f_throw", "f__svec_ref",
                     "genericmemory_copyto")


### PR DESCRIPTION
## Summary

`fn_may_allocate` (`src/classify.jl`) whitelists `get_pgcstack` and `get_pgcstack_static` as never-allocating, but omits `get_pgcstack_fallback` — the variant aarch64 (Apple Silicon) codegen emits to fetch the per-task GC stack pointer.

As a result, `classify_runtime_fn("jl_get_pgcstack_fallback")` returns `(:runtime, true)`, and `check_allocs` reports a spurious `AllocatingRuntimeCall` for allocation-free functions on aarch64.

This one-liner adds `"get_pgcstack_fallback"` to the never-allocates allowlist, right next to `"get_pgcstack_static"`. It mirrors the earlier `_static` fix in e44be86.

Fixes #104.

## Verification

```julia
julia> using AllocCheck

# before this PR (v0.2.5):
julia> AllocCheck.classify_runtime_fn("jl_get_pgcstack_fallback"; ignore_throw=true)
(:runtime, true)

# after this PR:
julia> AllocCheck.classify_runtime_fn("jl_get_pgcstack_fallback"; ignore_throw=true)
(:runtime, false)
```

`Pkg.test()` passes on Julia 1.10 with the patch applied.

## Context

- Precedent: e44be86 ("fix: add get_pgcstack_static to non-allocating allowlist") added the `_static` variant for exactly the same reason; `get_pgcstack_fallback` is a third pgcstack-fetch variant the whitelist missed.
- Downstream report: SciML/FastAlmostBandedMatrices.jl#68 (zero-allocation tests fail only on macOS/aarch64, traced to this false positive).
