### PR TITLE
Cache relocatable machine code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-GPUCompiler = "1.3, 2.1"
-LLVM = "9.8.1"
+GPUCompiler = "2.2"
+LLVM = "9.11"
 ExprTools = "0.1"
 MacroTools = "0.5"
 julia = "1.10"

--- a/src/AllocCheck.jl
+++ b/src/AllocCheck.jl
@@ -101,7 +101,6 @@ function find_allocs!(mod::LLVM.Module, meta, entry_name::String; ignore_throw=t
     worklist = LLVM.Function[ entry ]
     seen = LLVM.Function[ entry ]
     if invoke_entry
-        @assert startswith(name(entry), "jfptr")
         f = pop!(worklist)
         for block in blocks(f)
             for inst in instructions(block)
@@ -217,20 +216,28 @@ function check_allocs(@nospecialize(func), @nospecialize(types); ignore_throw=tr
         throw(MethodError(func, types))
     end
     source = GPUCompiler.methodinstance(Base._stable_typeof(func), Base.to_tuple_type(types))
-    config = alloc_config(:specfunc; validate=false, optimize=false, cleanup=false)
+    config = alloc_config(:specfunc; ignore_throw, validate=false, optimize=false, cleanup=false)
     job = CompilerJob(source, config)
-    allocs = JuliaContext() do ctx
-        mod, meta = GPUCompiler.compile(:llvm, job)
-        (; entry, compiled) = meta
-        entry_name = name(entry)
-        optimize!(mod)
 
-        allocs = find_allocs!(mod, meta, entry_name; ignore_throw, invoke_entry=false)
-        # display(mod)
-        # dispose(mod)
-        allocs
+    # the analysis results are session-portable, so cache them across sessions
+    res = GPUCompiler.cached_results(AllocCheckResults, job)
+    if res === nothing || res.analysis === nothing
+        analysis = JuliaContext() do ctx
+            mod, meta = GPUCompiler.compile(:llvm, job)
+            entry_name = name(meta.entry)
+            optimize!(mod)
+
+            # the analysis needs concrete values (e.g. type tags)
+            GPUCompiler.apply_relocations!(mod, meta.relocations)
+
+            find_allocs!(mod, meta, entry_name; ignore_throw, invoke_entry=false)
+        end
+        # compiling may have created the CodeInstance we attach results to
+        res = @something(res, GPUCompiler.cached_results(AllocCheckResults, job),
+                         AllocCheckResults())
+        res.analysis = analysis
     end
-    return allocs
+    return res.analysis
 end
 
 

--- a/src/classify.jl
+++ b/src/classify.jl
@@ -21,8 +21,10 @@ function classify_runtime_fn(name::AbstractString; ignore_throw::Bool)
                 "genericmemory_copy", "genericmemory_copy_slice",
                 "string_to_genericmemory", "ptr_to_genericmemory", "array_copy", "alloc_string",
                 "alloc_array_1d", "alloc_array_2d", "alloc_array_3d", "gc_alloc_typed",
+                "gc_alloc_typed_reset_safe", "gc_big_alloc_reset_safe",
                 "gc_small_alloc", "gc_pool_alloc", "gc_small_alloc_instrumented",
-                "gc_pool_alloc_instrumented", "gc_big_alloc_instrumented"
+                "gc_small_alloc_reset_safe", "gc_pool_alloc_instrumented",
+                "gc_big_alloc_instrumented"
                ) || occursin(r"^box_.*", name)
         return (:alloc, may_alloc)
     elseif name in ("f__apply_latest", "f__apply_iterate", "f__apply_pure", "f__call_latest",
@@ -171,7 +173,10 @@ function resolve_allocations(call::LLVM.Value)
     isnothing(match_) && return nothing
     name = match_[2]
 
-    if name in ("gc_pool_alloc_instrumented", "gc_small_alloc_instrumented", "gc_big_alloc_instrumented", "gc_alloc_typed")
+    if name in ("gc_pool_alloc_instrumented", "gc_small_alloc_instrumented",
+                "gc_big_alloc_instrumented", "gc_alloc_typed",
+                "gc_alloc_typed_reset_safe", "gc_big_alloc_reset_safe",
+                "gc_small_alloc_reset_safe")
         type = resolve_static_type_tag(operands(call)[end-1])
         return type !== nothing ? [(call, type)] : nothing
     elseif name in ("alloc_array_1d", "alloc_array_2d", "alloc_array_3d")

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1,13 +1,16 @@
 import LLVM, GPUCompiler
 using LLVM: TargetMachine, @dispose
-using GPUCompiler: CompilerConfig, CompilerJob, MemoryBuffer, NativeCompilerTarget, JuliaContext, ThreadSafeContext, run!
+using GPUCompiler: CompilerConfig, CompilerJob, MemoryBuffer, NativeCompilerTarget, JuliaContext, run!
 
 include("compiler_utils.jl")
 
 function __init__()
     opt_level = Base.JLOptions().opt_level
+    target = DefaultCompilerTarget()
 
-    tm[] = LLVM.JITTargetMachine(LLVM.triple(), cpu_name(), cpu_features();
+    # Match the target recorded in the compiler cache key. Julia's CPU feature string may
+    # include unavailable features implied by the CPU name, while LLVM filters with CPUID.
+    tm[] = LLVM.JITTargetMachine(LLVM.triple(), target.cpu, target.features;
                                  optlevel = llvm_codegen_level(opt_level))
     LLVM.asm_verbosity!(tm[], true)
     lljit = LLVM.JuliaOJIT()
@@ -46,6 +49,7 @@ struct CompileResult{Success, F, TT, RT}
     return_type::Type{RT}
     func::F
     analysis # TODO: add type
+    roots::Any  # keeps relocation targets alive for as long as `f_ptr` is callable
 end
 
 # lock + JIT objects
@@ -55,14 +59,44 @@ const tm = Ref{TargetMachine}() # for opt pipeline
 
 # cache of kernel instances
 const _kernel_instances = Dict{Any, Any}()
-const compiler_cache = Dict{Any, CompileResult}()
-alloc_config(func_abi::Symbol; kwargs...) =
-    CompilerConfig(DefaultCompilerTarget(), NativeParams();
+alloc_config(func_abi::Symbol; ignore_throw::Bool=true, kwargs...) =
+    CompilerConfig(DefaultCompilerTarget(), NativeParams(ignore_throw);
                    kernel=false, entry_abi = func_abi, always_inline=false, kwargs...)
+
+# compilation results attached to each cached CodeInstance through
+# `GPUCompiler.cached_results`; on Julia 1.11+ these also persist through package
+# precompilation.
+mutable struct AllocCheckResults
+    # session-portable artifacts: a relocatable object file, the manifest of relocations left
+    # for the loader to write into it, and the allocation analysis
+    object::Union{Nothing,Vector{UInt8}}
+    entry::Union{Nothing,String}
+    relocations::GPUCompiler.Relocations
+    analysis::Union{Nothing,Vector{Any}}
+
+    # session-local JIT handle; never persisted (see `compile_callable`)
+    ptr::Ptr{Cvoid}
+
+    AllocCheckResults() = new(nothing, nothing, GPUCompiler.Relocations(), nothing, C_NULL)
+end
 
 const NativeCompilerJob = CompilerJob{NativeCompilerTarget,NativeParams}
 GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = true
 GPUCompiler.runtime_module(::NativeCompilerJob) = Runtime
+# Emit each host reference as a named, null-initialized global for us to write after loading
+# the object, rather than baking this session's addresses into the code. That keeps the
+# cached *object* session-portable, so a later session (or a package image) starts it up with
+# no compiler involved at all: add the object, write one word per record (see `link_result`).
+#
+# Every object we load lands in one shared JITDylib (before Julia 1.14, at least), so two
+# results referencing the same value must not define the same symbol. GPUCompiler namespaces
+# record names per compiler job, which makes that so by construction.
+GPUCompiler.relocation_lowering(@nospecialize(job::NativeCompilerJob)) = :patch
+
+# Emit machine code through the JIT target machine, whose relocation and code model suit
+# loading the result into the session's ORC JIT.
+GPUCompiler.mcgen(@nospecialize(job::NativeCompilerJob), mod::LLVM.Module,
+                  format=LLVM.API.LLVMAssemblyFile) = String(LLVM.emit(tm[], mod, format))
 
 function optimize!(mod::LLVM.Module)
     pipeline = LLVM.Interop.JuliaPipeline(opt_level=Base.JLOptions().opt_level)
@@ -80,57 +114,121 @@ automatically and checked for allocations whenever the function changes or when 
 types or keyword arguments are provided.
 """
 function compile_callable(f::F, tt::TT=Tuple{}; ignore_throw=true) where {F, TT}
-    # cuda = active_state()
-
     Base.@lock codegen_lock begin
-        # compile the function
-        cache = compiler_cache
         source = GPUCompiler.methodinstance(F, tt)
         rt = Core.Compiler.return_type(f, tt)
+        method = source.def::Method
+        namespace = join(Base.fullname(method.module), '_')
+        entry = "alloccheck_$(namespace)_$(GPUCompiler.mangle_sig(source.specTypes))"
+        config = alloc_config(:func; ignore_throw, validate=false, name=entry)
+        job = CompilerJob(source, config)
 
-        function compile(@nospecialize(job::CompilerJob))
-            return JuliaContext() do ctx
+        # Explicitly enroll the foreign CodeInstance in a package image. Codegen creates
+        # one on a miss, but Julia only serializes it reliably when it is precompiled.
+        if ccall(:jl_generating_output, Cint, ()) == 1
+            precompile(job)
+        end
+
+        # look up (or generate) the compilation artifacts and analysis
+        res = GPUCompiler.cached_results(AllocCheckResults, job)
+        if res === nothing || res.object === nothing
+            artifacts = JuliaContext() do ctx
                 mod, meta = GPUCompiler.compile(:llvm, job)
-                (; entry, compiled) = meta
-                entry_name = name(entry)
+                entry = name(meta.entry)
                 optimize!(mod)
+                relocations = meta.relocations
 
-                clone = copy(mod)
-                analysis = find_allocs!(mod, meta, entry_name; ignore_throw, invoke_entry=true)
-                # TODO: This is the wrong meta
-                return clone, entry_name, analysis
+                # Julia's JIT expects some symbols to be present that it would otherwise
+                # inject itself, when handed IR rather than an object (Win64 unwind data).
+                LLVM.decorate_module(mod)
+
+                # Snapshot the module while its sites are still symbolic: the object needs
+                # them that way, while the analysis needs them *resolved* to read concrete
+                # values (e.g. type tags) out of the IR.
+                bitcode = let io = IOBuffer()
+                    write(io, mod)
+                    take!(io)
+                end
+
+                # `emit_asm` lowers the sites in place and prunes the ones optimization
+                # killed, leaving exactly the manifest the object still needs written
+                asm, _ = GPUCompiler.emit_asm(job, mod, relocations,
+                                              LLVM.API.LLVMObjectFile)
+                object = Vector{UInt8}(codeunits(asm))
+
+                analysis = let analysis_mod = parse(LLVM.Module, MemoryBuffer(bitcode))
+                    GPUCompiler.apply_relocations!(analysis_mod, relocations)
+                    find_allocs!(analysis_mod, meta, entry; ignore_throw, invoke_entry=true)
+                end
+
+                (; object, entry, relocations, analysis)
             end
+            # Compiling may have created the CodeInstance we attach results to. GPUCompiler
+            # selects persistent or session-local storage from the relocation strategy.
+            res = @something(res, GPUCompiler.cached_results(AllocCheckResults, job),
+                             AllocCheckResults())
+            res.object = artifacts.object
+            res.entry = artifacts.entry
+            res.relocations = artifacts.relocations
+            res.analysis = artifacts.analysis
         end
-        function link(@nospecialize(job::CompilerJob), (mod, entry_name, analysis))
-            return JuliaContext() do ctx
-                lljit = jit[].jit
-                jd = LLVM.JITDylib(lljit)
-                buf = convert(MemoryBuffer, mod)
-                tsm = ThreadSafeContext() do ctx
-                    mod = parse(LLVM.Module, buf)
-                    GPUCompiler.ThreadSafeModule(mod)
-                end
-                LLVM.add!(lljit, jd, tsm)
-                f_ptr = pointer(LLVM.lookup(lljit, jd, entry_name))
-                if f_ptr == C_NULL
-                    throw(GPUCompiler.InternalCompilerError(job,
-                          "Failed to compile @check_allocs function"))
-                end
-                if length(analysis) == 0
-                    CompileResult{true, typeof(f), tt, rt}(f_ptr, tt, rt, f, analysis)
-                else
-                    CompileResult{false, typeof(f), tt, rt}(f_ptr, tt, rt, f, analysis)
-                end
+
+        # (re)link the code into the session's JIT, resolving relocations
+        if res.ptr == C_NULL
+            f_ptr = link_result(job, res)
+            # don't persist JIT handles into package images
+            if ccall(:jl_generating_output, Cint, ()) != 1
+                res.ptr = f_ptr
             end
+        else
+            f_ptr = res.ptr
         end
-        config = alloc_config(:func, validate=false)
-        fun = GPUCompiler.cached_compilation(cache, source, config, compile, link)
+
+        analysis = res.analysis::Vector{Any}
+        fun = if length(analysis) == 0
+            CompileResult{true, typeof(f), tt, rt}(f_ptr, tt, rt, f, analysis, res)
+        else
+            CompileResult{false, typeof(f), tt, rt}(f_ptr, tt, rt, f, analysis, res)
+        end
 
         # create a callable object that captures the function instance. we don't need to think
         # about world age here, as GPUCompiler already does and will return a different object
         key = (objectid(source), hash(fun), f)
         return get(_kernel_instances, key, fun)::CompileResult
     end
+end
+
+# Results linked while precompiling cannot retain their pointer. Remember them by identity so
+# another lookup in the same session does not add the object a second time. Entry names are
+# not suitable keys: different cached objects can contain the same Julia codegen name.
+const _linked = IdDict{AllocCheckResults,Ptr{Cvoid}}()
+
+# Load cached relocatable code into this session's JIT and write this session's host
+# addresses into it. No compiler runs here — the object is already machine code — which is
+# what makes a cached (or precompiled) result a genuine warm start.
+function link_result(@nospecialize(job::CompilerJob), res::AllocCheckResults)
+    entry = res.entry::String
+    haskey(_linked, res) && return _linked[res]
+
+    lljit = jit[].jit
+    jd = LLVM.JITDylib(lljit, entry)
+    LLVM.add!(lljit, jd, MemoryBuffer(res.object::Vector{UInt8}))
+
+    # `resolved_relocations` permanently roots the referenced values, so the words it hands
+    # back cannot dangle for as long as the code stays loaded
+    for (rec, word) in GPUCompiler.resolved_relocations(res.relocations)
+        addr = pointer(LLVM.lookup(lljit, jd, rec.name))
+        addr == C_NULL && throw(GPUCompiler.InternalCompilerError(job,
+              "Relocation '$(rec.name)' is absent from the loaded object"))
+        unsafe_store!(Ptr{UInt}(addr + rec.offset), word)
+    end
+
+    f_ptr = pointer(LLVM.lookup(lljit, jd, entry))
+    if f_ptr == C_NULL
+        throw(GPUCompiler.InternalCompilerError(job,
+              "Failed to compile @check_allocs function"))
+    end
+    return _linked[res] = f_ptr
 end
 
 function (f::CompileResult{Success, F, TT, RT})(args...) where {Success, F, TT, RT}

--- a/src/compiler_utils.jl
+++ b/src/compiler_utils.jl
@@ -1,7 +1,12 @@
 import LLVM, GPUCompiler
 using GPUCompiler: NativeCompilerTarget
 
-struct NativeParams <: GPUCompiler.AbstractCompilerParams end
+# `ignore_throw` is part of the compiler configuration (rather than only a keyword to the
+# analysis) so that cached analysis results are keyed by it.
+struct NativeParams <: GPUCompiler.AbstractCompilerParams
+    ignore_throw::Bool
+end
+NativeParams() = NativeParams(true)
 
 DefaultCompilerTarget(; kwargs...) = NativeCompilerTarget(; jlruntime=true, kwargs...)
 
@@ -13,12 +18,4 @@ function llvm_codegen_level(opt_level::Integer)
     else
         optlevel = LLVM.API.LLVMCodeGenLevelAggressive
     end
-end
-
-function cpu_name()
-    ccall(:jl_get_cpu_name, String, ())
-end
-
-function cpu_features()
-    return ccall(:jl_get_cpu_features, String, ())
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -361,3 +361,42 @@ end
     # issue #96
     @test length(check_allocs(svec_alloc, (ErrorException,))) > 0
 end
+
+# non-allocating, but each carries a relocation for the same `Symbol`
+reloc_probe_a(x::Symbol) = x === :reloc_probe
+reloc_probe_b(x::Symbol) = x === :reloc_probe
+entry_probe(x::Float64) = x + 1
+entry_probe(x::Float32) = x - 1
+
+@testset "relocation patching" begin
+    # A compiled result is cached as a machine-code object plus one word per host reference,
+    # which `link_result` writes into the loaded image after adding it. That is what lets a
+    # later session — or a package image — start the code with no compiler at all, but it
+    # only works if those words actually land.
+    ra = AllocCheck.compile_callable(reloc_probe_a, Tuple{Symbol})
+    rb = AllocCheck.compile_callable(reloc_probe_b, Tuple{Symbol})
+
+    if AllocCheck.GPUCompiler.supports_relocatable_ir()
+        # Both results reference `:reloc_probe`, and both objects are loaded into the same
+        # JITDylib, so they must not name that word identically — the second `add!` would be
+        # a duplicate definition. GPUCompiler namespaces relocation names per compiler job,
+        # which makes that true by construction; assert the guarantee holds.
+        names(r) = Set(rec.name for rec in r.roots.relocations.records)
+        @test !isempty(names(ra)) && !isempty(names(rb))
+        @test isdisjoint(names(ra), names(rb))
+    end
+
+    # a slot left unpatched reads zero and could never match, so these answers are the patch
+    @test ra(:reloc_probe) == true
+    @test ra(:other_probe) == false
+    @test rb(:reloc_probe) == true
+
+    # Julia may give both overloads the same `jfptr_entry_probe_0` codegen name. Cached
+    # objects need signature-derived entry names to coexist and to remain distinct in the
+    # session's link cache.
+    r64 = AllocCheck.compile_callable(entry_probe, Tuple{Float64})
+    r32 = AllocCheck.compile_callable(entry_probe, Tuple{Float32})
+    @test r64.roots.entry != r32.roots.entry
+    @test r64(2.0) === 3.0
+    @test r32(2.0f0) === 1.0f0
+end


### PR DESCRIPTION
Builds on JuliaGPU/GPUCompiler.jl#878 to cache AllocCheck machine-code objects across Julia sessions.

Host references are emitted as named writable globals. AllocCheck stores the object, entry point, relocation manifest, and allocation analysis with the GPUCompiler CodeInstance; a fresh session loads the object into ORC and patches every relocation before calling it. Function pointers remain session-local.

Entry names are derived from the full method signature and each object gets an isolated JITDylib, so overloaded methods cannot alias. Object emission uses the same CPU target as the GPUCompiler cache key, and foreign CodeInstances are explicitly enrolled during package precompilation.

The fallback remains session-local when Julia cannot provide relocatable global metadata. Tests cover repeated references, overloaded callables, warm object execution, and Julia main reset-safe allocation entry points.

Requires GPUCompiler 2.2.