### PR TITLE
Test that boxed Bool results are the runtime's jl_true/jl_false

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -361,3 +361,21 @@ end
     # issue #96
     @test length(check_allocs(svec_alloc, (ErrorException,))) > 0
 end
+
+@check_allocs returns_bool(x::Float64) = x > 0
+
+@testset "boxed Bool identity" begin
+    valptr(@nospecialize x) = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), x)
+
+    # A `@check_allocs` function returns through the boxed `:func` ABI, so a
+    # `Bool` result comes back as the `jl_true`/`jl_false` singleton. Those must
+    # be the runtime's own objects: a module-local replica lives in read-only
+    # data, and the collector segfaults setting mark bits in it once such a
+    # pointer reaches GC-tracked memory.
+    @test valptr(returns_bool(1.0)) == valptr(true)
+    @test valptr(returns_bool(-1.0)) == valptr(false)
+
+    keep = Any[returns_bool(1.0), returns_bool(-1.0)]
+    GC.gc(true)
+    @test keep == Any[true, false]
+end


### PR DESCRIPTION
Adds a regression test for the GC crash we hit on Enzyme around the handling of `jl_true`/`jl_false`.

## Background

GPUCompiler 2.1.x (`relocate_gvs!` / `materialize_bool_singletons!`, from JuliaGPU/GPUCompiler.jl#874) rewrites `jl_true`/`jl_false` — and other non-ghost isbits boxed constants — into module-local constant replicas so the module is session-portable. That is right for device targets, but AllocCheck compiles with `jlruntime=true` (`src/compiler_utils.jl:6`) and then *executes* the result against the live Julia runtime.

A materialized box is a replica in the module's read-only data, not a heap object. As soon as such a pointer is stored into GC-tracked memory the collector tries to set mark bits in it:

```
signal (11): Segmentation fault
gc_try_setmark_tag at src/gc-stock.c:257 [inlined]
gc_try_claim_and_push at src/gc-stock.c:1685 [inlined]
gc_mark_obj8 at src/gc-stock.c:1705 [inlined]
gc_mark_outrefs at src/gc-stock.c:2463 [inlined]
```

A `@check_allocs` function returns through the boxed `:func` ABI, so any `Bool`-returning one reproduces it. On released GPUCompiler 2.1.1:

```
>>> called, r = true :: Bool
>>> ptr(r)    = Ptr{Nothing}(0x00007ffb82503cd8)
>>> ptr(true) = Ptr{Nothing}(0x00007ffb96b8d670)
>>> materialized replica = true
>>> gc with r rooted...
[3125671] signal 11 (2): Segmentation fault
```

## The test

The new `"boxed Bool identity"` testset asserts the returned box *is* the runtime's singleton (a cheap pointer comparison that fails before the process dies), then roots both results and forces a collection.

The fix belongs in GPUCompiler — gating materialization on `materialize = !uses_julia_runtime(job)` — and is still in progress, so this PR is test-only and **is expected to fail CI** until that lands and `[compat]` is tightened past the affected versions. The rest of the suite is unaffected: the existing tests never exercised this path and pass on both 2.1.1 and the fixed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)